### PR TITLE
remove the usage of signalservice.Content

### DIFF
--- a/textsecure.go
+++ b/textsecure.go
@@ -653,10 +653,11 @@ func handleReceivedMessage(msg []byte) error {
 		if err != nil {
 			return err
 		}
-		err = handleMessage(env.GetSourceE164(), env.GetTimestamp(), b)
-		if err != nil {
-			return err
-		}
+
+		client.MessageHandler(&Message{
+			source:  env.GetSourceE164(),
+			message: string(b),
+		})
 	default:
 		return MessageTypeNotImplementedError{uint32(*env.Type)}
 	}

--- a/textsecure.go
+++ b/textsecure.go
@@ -626,10 +626,11 @@ func handleReceivedMessage(msg []byte) error {
 		if err != nil {
 			return err
 		}
-		err = handleMessage(env.GetSourceE164(), env.GetTimestamp(), b)
-		if err != nil {
-			return err
-		}
+
+		client.MessageHandler(&Message{
+			source:  env.GetSourceE164(),
+			message: string(stripPadding(b)),
+		})
 
 	case signalservice.Envelope_PREKEY_BUNDLE:
 		msg := env.GetContent()
@@ -656,7 +657,7 @@ func handleReceivedMessage(msg []byte) error {
 
 		client.MessageHandler(&Message{
 			source:  env.GetSourceE164(),
-			message: string(b),
+			message: string(stripPadding(b)),
 		})
 	default:
 		return MessageTypeNotImplementedError{uint32(*env.Type)}


### PR DESCRIPTION
The swift library doesn't use the protobuf `Content`. This PR removes it to solve the incapability issue.

I'm not sure if `resp.NeedsSync` is required, and the related code is currently commented out as a quick fix.